### PR TITLE
Disable some warnings and other fixes to get compiling under GCC.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ SRC_CFLAGS := -pedantic
 TEST_CFLAGS := -Wno-unused-parameter -iquote$(SRC_DIR)
 SP := strip
 
+# GCC fails with decode.h zero-length format strings
+# GCC fails with dis.c notimplemented instructions having unused parameters
+# GCC fails with dis.c notimplemented instructions having unused variables
+CFLAGS += -Wno-format-zero-length -Wno-unused-parameter -Wno-unused-variable
+
 ifdef XCF
 CFLAGS += $(XCF)
 endif

--- a/src/cart.c
+++ b/src/cart.c
@@ -51,10 +51,16 @@ static int detect_format(struct cartridge *self, FILE *f)
 static int parse_ines(struct cartridge *self, FILE *f)
 {
     unsigned char header[16];
+    size_t items_expected, items_read = 0, item_size;
 
-    fread(header, sizeof header[0], sizeof header, f);
-    if (feof(f)) return CART_ERR_EOF;
-    if (ferror(f)) return CART_ERR_IO;
+    item_size = sizeof header[0];
+    items_expected = sizeof header;
+    while (items_read < items_expected) {
+	items_read = fread(&header[item_size * items_read], item_size, items_expected, f);
+
+	if (feof(f)) return CART_ERR_EOF;
+	if (ferror(f)) return CART_ERR_IO;
+    }
 
     // NOTE: if last 4 bytes of header aren't 0 this is a very old format
     uint32_t tail;

--- a/src/cart.c
+++ b/src/cart.c
@@ -56,7 +56,8 @@ static int parse_ines(struct cartridge *self, FILE *f)
     item_size = sizeof header[0];
     items_expected = sizeof header;
     while (items_read < items_expected) {
-	items_read = fread(&header[item_size * items_read], item_size, items_expected, f);
+	items_read = fread(&header[item_size * items_read], item_size,
+			   items_expected - items_read, f);
 
 	if (feof(f)) return CART_ERR_EOF;
 	if (ferror(f)) return CART_ERR_IO;

--- a/src/cart.c
+++ b/src/cart.c
@@ -56,8 +56,8 @@ static int parse_ines(struct cartridge *self, FILE *f)
     item_size = sizeof header[0];
     items_expected = sizeof header;
     while (items_read < items_expected) {
-	items_read = fread(&header[item_size * items_read], item_size,
-			   items_expected - items_read, f);
+	items_read += fread(&header[item_size * items_read], item_size,
+			    items_expected - items_read, f);
 
 	if (feof(f)) return CART_ERR_EOF;
 	if (ferror(f)) return CART_ERR_IO;

--- a/src/mappers.c
+++ b/src/mappers.c
@@ -31,10 +31,21 @@ struct ines_000_mapper {
 
 static int load_chunks(uint8_t *restrict *mem, size_t size, FILE *f)
 {
+    size_t items_expected, items_read = 0, item_size;
+
     *mem = calloc(size, sizeof **mem);
-    fread(*mem, sizeof **mem, size, f);
-    if (feof(f)) return CART_ERR_EOF;
-    if (ferror(f)) return CART_ERR_IO;
+
+    item_size = sizeof **mem;
+    items_expected = size;
+
+    while (items_read < items_expected) {
+	items_read += fread(mem[item_size * items_read], item_size,
+			    items_expected - items_read, f);
+
+	if (feof(f)) return CART_ERR_EOF;
+	if (ferror(f)) return CART_ERR_IO;
+    }
+
     return 0;
 }
 

--- a/src/uibatch.c
+++ b/src/uibatch.c
@@ -28,7 +28,8 @@ static uint64_t Ticks;
 
 static void clearline(void)
 {
-    static const size_t linelength = strlen(DistractorFormat) * 2;
+    static size_t linelength;
+    linelength = strlen(DistractorFormat) * 2;
     for (size_t i = 0; i < linelength; ++i) {
         fputc('\b', stderr);
     }


### PR DESCRIPTION
First, thanks for the project.  It's been helpful as a reference point and example of good C work.

I've added some changes to make it compile under GCC.  I made some decisions that you might want to change.  First, I didn't make any shell calls to autodetect the compiler in the Makefile, instead I just ignored the GCC-related warnings.  I could change it to use Makefile conditionals with clang/gcc shell detection if you want.

Second, I dealt with the return value from fread, even if file sizes never reach buffer limits.

I haven't tested everything thoroughly, you might want to test under different architectures with different samples.

Thanks again, let me know if it's helpful.

Disable some warnings and other fixes to get compiling under GCC.
GCC doesn't allow initializing constants with functions.
Handle return from fread  